### PR TITLE
Adding CI to run tests and linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn
+    - run: yarn test
+    - run: yarn lint
+      env:
+        CI: true

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"realm": "^6.1.2",
 		"redux": "^4.0.5",
 		"redux-saga": "^1.1.3",
-		"repeat-please-styles": "git+ssh://git@github.com:marciomarquessouza/repeat-please-styles.git"
+		"repeat-please-styles": "git+https://:marciomarquessouza@github.com/marciomarquessouza/repeat-please-styles.git"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8160,9 +8160,9 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-"repeat-please-styles@git+ssh://git@github.com:marciomarquessouza/repeat-please-styles.git":
+"repeat-please-styles@git+https://:marciomarquessouza@github.com/marciomarquessouza/repeat-please-styles.git":
   version "0.0.1"
-  resolved "git+ssh://git@github.com:marciomarquessouza/repeat-please-styles.git#881f68d6d3ff65f15f19bcab8e4c71bc296a3886"
+  resolved "git+https://:marciomarquessouza@github.com/marciomarquessouza/repeat-please-styles.git#881f68d6d3ff65f15f19bcab8e4c71bc296a3886"
   dependencies:
     "@types/react-native-vector-icons" "^6.4.5"
     moment "^2.24.0"


### PR DESCRIPTION
This PR adds a simple Github Action workflow to run tests and linter upon commits.

I have also changed the `styles` dependency from `git` to `https`. This makes it easier to run the CI as there is no need to configure any ssh key on the CI process, and, since it is a open repository, it does no harm in using https. Please, let me know if that is ok.